### PR TITLE
Make pubDate a valid RFC822 date as per RSS specs

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -65,12 +65,12 @@ class Plugin extends PluginBase
     protected function createRss()
     {
         $fileContents = "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n" .
-                        "<rss version=\"2.0\">\n".
+                        "<rss version=\"2.0\" xmlns:atom=\"http://www.w3.org/2005/Atom\">\n".
                         "\t<channel>\n".
                         "\t\t<title>" . Settings::get('title') . "</title>\n" .
                         "\t\t<link>" . Settings::get('link') . "</link>\n" .
-                        "\t\t<description>" . Settings::get('description') . "</description>\n\n";
-
+                        "\t\t<description>" . Settings::get('description') . "</description>\n".
+                        "\t\t<atom:link href=\"" . Settings::get('link') . "/rss.xml\" rel=\"self\" type=\"application/rss+xml\" />\n\n";
 
         foreach($this->loadPosts() as $post)
         {


### PR DESCRIPTION
The RSS2.0 specs specifies that the pubDate element has to be in the RFC822 format.
Currently the plugin does not use this format and some RSS readers may not be able to read the file, also it's  obviously not valid RSS as per http://validator.w3.org/feed/

This change makes the date RFC882 and the RSS valid and fixes another warning related to missing atom:link in the validator
