### PR TITLE
Properly escape post title

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -84,7 +84,7 @@ class Plugin extends PluginBase
             $description = Markdown::parse(trim($description));
 
             $fileContents .= "\t\t<item>\n" .
-                             "\t\t\t<title>" . $post->title . "</title>\n" .
+                             "\t\t\t<title>" . htmlspecialchars($post->title, ENT_QUOTES, 'UTF-8') . "</title>\n" .
                              "\t\t\t<link>" . Settings::get('link') . Settings::get('postPage') . "/" . $post->slug . "</link>\n" .
                              "\t\t\t<guid>" . Settings::get('link') . Settings::get('postPage') . "/" . $post->slug . "</guid>\n" .
                              "\t\t\t<pubDate>" . $published->format(DateTime::RFC2822) . "</pubDate>\n" .

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -12,3 +12,4 @@
     - Changed having to where to help database type compatibility
     - Updated the output to parse markdown
 1.0.9: Update to work with new RC version of October.
+1.1.0: Properly escape post title


### PR DESCRIPTION
This wraps `$post->title` with `htmlspecialchars` to escape it properly. This resolves #4.